### PR TITLE
feat: Windows background music parity with Linux

### DIFF
--- a/.claude/hooks-windows/background-music-manager.ps1
+++ b/.claude/hooks-windows/background-music-manager.ps1
@@ -1,0 +1,348 @@
+#
+# File: .claude/hooks-windows/background-music-manager.ps1
+#
+# AgentVibes - Background Music Manager (Windows)
+# Manages background music settings for TTS
+#
+
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = "status",
+
+    [Parameter(Position = 1)]
+    [string]$Arg1 = "",
+
+    [Parameter(Position = 2)]
+    [string]$Arg2 = ""
+)
+
+# Resolve paths relative to this script
+$ScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ClaudeDir = Split-Path -Parent $ScriptPath
+$ConfigDir = Join-Path $ClaudeDir "config"
+$TracksDir = Join-Path (Join-Path $ClaudeDir "audio") "tracks"
+$EnabledFile = Join-Path $ConfigDir "background-music-enabled.txt"
+$VolumeFile = Join-Path $ConfigDir "background-music-volume.txt"
+$AudioEffectsCfg = Join-Path $ConfigDir "audio-effects.cfg"
+
+$DefaultVolume = "0.34"
+
+# Ensure config directory exists
+if (-not (Test-Path $ConfigDir)) {
+    New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
+}
+
+function Test-Enabled {
+    if (Test-Path $EnabledFile) {
+        $status = (Get-Content $EnabledFile -Raw).Trim()
+        return ($status -eq "true" -or $status -eq "on" -or $status -eq "1")
+    }
+    return $false
+}
+
+function Get-MusicVolume {
+    if (Test-Path $VolumeFile) {
+        return (Get-Content $VolumeFile -Raw).Trim()
+    }
+    return $DefaultVolume
+}
+
+function Set-Enabled {
+    param([string]$Value)
+    Set-Content -Path $EnabledFile -Value $Value -NoNewline
+}
+
+function Set-MusicVolume {
+    param([string]$Value)
+
+    if ($Value -notmatch '^\d*\.?\d+$') {
+        Write-Output "Error: Volume must be a number between 0.0 and 1.0"
+        exit 1
+    }
+
+    $num = [double]$Value
+    if ($num -lt 0 -or $num -gt 1) {
+        Write-Output "Error: Volume must be between 0.0 and 1.0"
+        exit 1
+    }
+
+    Set-Content -Path $VolumeFile -Value $Value -NoNewline
+}
+
+function Get-DefaultTrack {
+    if (-not (Test-Path $AudioEffectsCfg)) { return "" }
+
+    $lines = Get-Content $AudioEffectsCfg
+    foreach ($line in $lines) {
+        if ($line -match '^default\|') {
+            $parts = $line -split '\|'
+            if ($parts.Length -ge 3) { return $parts[2] }
+        }
+    }
+    return ""
+}
+
+function Show-TrackList {
+    if (-not (Test-Path $TracksDir)) {
+        Write-Output "No tracks folder found at $TracksDir"
+        return
+    }
+
+    Write-Output "Available Background Music Tracks"
+    Write-Output "===================================="
+    Write-Output ""
+
+    $files = Get-ChildItem -Path $TracksDir -File -Include "*.mp3", "*.wav", "*.ogg" -Recurse | Sort-Object Name
+    $count = 0
+
+    foreach ($file in $files) {
+        $count++
+        Write-Output ("{0,2}. {1}" -f $count, $file.Name)
+    }
+
+    if ($count -eq 0) {
+        Write-Output "No audio files found in tracks folder"
+    } else {
+        Write-Output ""
+        Write-Output "Total: $count track(s)"
+    }
+}
+
+function Set-DefaultTrack {
+    param([string]$Track)
+
+    if (-not $Track) {
+        Write-Output "Error: No track name provided"
+        Write-Output "Usage: background-music-manager.ps1 set-default TRACK_NAME"
+        exit 1
+    }
+
+    $trackPath = Join-Path $TracksDir $Track
+    if (-not (Test-Path $trackPath)) {
+        Write-Output "Error: Track '$Track' not found in tracks folder"
+        Write-Output "Run 'background-music-manager.ps1 list' to see available tracks"
+        exit 1
+    }
+
+    if (-not (Test-Path $AudioEffectsCfg)) {
+        Write-Output "Error: audio-effects.cfg not found at $AudioEffectsCfg"
+        exit 1
+    }
+
+    $lines = Get-Content $AudioEffectsCfg
+    $found = $false
+    $newLines = @()
+
+    foreach ($line in $lines) {
+        if ($line -match '^default\|') {
+            $parts = $line -split '\|'
+            if ($parts.Length -ge 4) {
+                $newLines += "$($parts[0])|$($parts[1])|$Track|$($parts[3])"
+            } else {
+                $newLines += "default||$Track|0.30"
+            }
+            $found = $true
+        } else {
+            $newLines += $line
+        }
+    }
+
+    if (-not $found) {
+        Write-Output "Error: No default entry found in audio-effects.cfg"
+        exit 1
+    }
+
+    Set-Content -Path $AudioEffectsCfg -Value ($newLines -join "`n")
+
+    if (-not (Test-Enabled)) {
+        Set-Enabled "true"
+        Write-Output "[OK] Default background music set to: $Track"
+        Write-Output "[OK] Background music enabled automatically"
+    } else {
+        Write-Output "[OK] Default background music set to: $Track"
+    }
+}
+
+function Set-AgentTrack {
+    param([string]$Agent, [string]$Track)
+
+    if (-not $Agent -or -not $Track) {
+        Write-Output "Error: Agent name and track required"
+        Write-Output "Usage: background-music-manager.ps1 set-agent AGENT_NAME TRACK_NAME"
+        exit 1
+    }
+
+    $trackPath = Join-Path $TracksDir $Track
+    if (-not (Test-Path $trackPath)) {
+        Write-Output "Error: Track not found: $Track"
+        Write-Output "Run 'background-music-manager.ps1 list' to see available tracks"
+        exit 1
+    }
+
+    if (-not (Test-Path $AudioEffectsCfg)) {
+        Write-Output "Error: audio-effects.cfg not found"
+        exit 1
+    }
+
+    $lines = Get-Content $AudioEffectsCfg
+    $found = $false
+    $newLines = @()
+
+    foreach ($line in $lines) {
+        if ($line -match "^${Agent}\|") {
+            $parts = $line -split '\|'
+            if ($parts.Length -ge 4) {
+                $newLines += "$($parts[0])|$($parts[1])|$Track|$($parts[3])"
+            } else {
+                $newLines += "${Agent}||${Track}|0.30"
+            }
+            $found = $true
+        } else {
+            $newLines += $line
+        }
+    }
+
+    if (-not $found) {
+        $newLines += "${Agent}||${Track}|0.30"
+        Write-Output "[OK] Added background music for ${Agent}: $Track"
+    } else {
+        Write-Output "[OK] Updated background music for ${Agent}: $Track"
+    }
+
+    Set-Content -Path $AudioEffectsCfg -Value ($newLines -join "`n")
+
+    if (-not (Test-Enabled)) {
+        Set-Enabled "true"
+        Write-Output "[OK] Background music enabled automatically"
+    }
+}
+
+function Set-AllAgentsTrack {
+    param([string]$Track)
+
+    if (-not $Track) {
+        Write-Output "Error: Track name required"
+        Write-Output "Usage: background-music-manager.ps1 set-all TRACK_NAME"
+        exit 1
+    }
+
+    $trackPath = Join-Path $TracksDir $Track
+    if (-not (Test-Path $trackPath)) {
+        Write-Output "Error: Track not found: $Track"
+        Write-Output "Run 'background-music-manager.ps1 list' to see available tracks"
+        exit 1
+    }
+
+    if (-not (Test-Path $AudioEffectsCfg)) {
+        Write-Output "Error: audio-effects.cfg not found"
+        exit 1
+    }
+
+    $lines = Get-Content $AudioEffectsCfg
+    $newLines = @()
+    $count = 0
+
+    foreach ($line in $lines) {
+        if ($line -match '^\s*#' -or $line -match '^\s*$') {
+            $newLines += $line
+            continue
+        }
+        if ($line -match '^_party_mode\|') {
+            $newLines += $line
+            continue
+        }
+        $parts = $line -split '\|'
+        if ($parts.Length -ge 4) {
+            $newLines += "$($parts[0])|$($parts[1])|$Track|$($parts[3])"
+            $count++
+        } else {
+            $newLines += $line
+        }
+    }
+
+    Set-Content -Path $AudioEffectsCfg -Value ($newLines -join "`n")
+    Write-Output "[OK] Updated background music for $count agents: $Track"
+
+    if (-not (Test-Enabled)) {
+        Set-Enabled "true"
+        Write-Output "[OK] Background music enabled automatically"
+    }
+}
+
+function Show-Status {
+    Write-Output "Background Music Status"
+    Write-Output "=========================="
+
+    if (Test-Enabled) {
+        Write-Output "Status: ENABLED"
+    } else {
+        Write-Output "Status: DISABLED"
+    }
+
+    $vol = Get-MusicVolume
+    $pct = [math]::Round([double]$vol * 100)
+    Write-Output ('Volume: {0} ({1}%)' -f $vol, $pct)
+
+    $defaultTrack = Get-DefaultTrack
+    if ($defaultTrack) {
+        Write-Output "Default Track: $defaultTrack"
+    } else {
+        Write-Output "Default Track: none"
+    }
+
+    if (Test-Path $TracksDir) {
+        $count = (Get-ChildItem -Path $TracksDir -File -Include "*.mp3", "*.wav", "*.ogg" -Recurse).Count
+        Write-Output "Tracks: $count audio file(s) in tracks folder"
+    } else {
+        Write-Output "Tracks: No tracks folder found"
+    }
+
+    Write-Output ""
+    Write-Output "Dependencies:"
+    if (Get-Command sox -ErrorAction SilentlyContinue) {
+        Write-Output "  sox: installed"
+    } else {
+        Write-Output "  sox: not installed (needed for effects)"
+    }
+    if (Get-Command ffmpeg -ErrorAction SilentlyContinue) {
+        Write-Output "  ffmpeg: installed"
+    } else {
+        Write-Output "  ffmpeg: not installed (needed for mixing)"
+    }
+}
+
+# Main command handler
+if ($Command -in "status", "") {
+    Show-Status
+} elseif ($Command -in "on", "enable", "true") {
+    Set-Enabled "true"
+    $vol = Get-MusicVolume
+    Write-Output "[OK] Background music ENABLED at $vol volume"
+} elseif ($Command -in "off", "disable", "false") {
+    Set-Enabled "false"
+    Write-Output "[OK] Background music DISABLED"
+} elseif ($Command -eq "volume") {
+    if (-not $Arg1) {
+        $vol = Get-MusicVolume
+        Write-Output "Current volume: $vol"
+    } else {
+        Set-MusicVolume $Arg1
+        Write-Output "[OK] Background music volume set to $Arg1"
+    }
+} elseif ($Command -eq "list") {
+    Show-TrackList
+} elseif ($Command -eq "set-default") {
+    Set-DefaultTrack $Arg1
+} elseif ($Command -eq "set-agent") {
+    Set-AgentTrack $Arg1 $Arg2
+} elseif ($Command -eq "set-all") {
+    Set-AllAgentsTrack $Arg1
+} elseif ($Command -eq "get-enabled") {
+    if (Test-Enabled) { Write-Output "true" } else { Write-Output "false" }
+} elseif ($Command -eq "get-volume") {
+    $vol = Get-MusicVolume
+    Write-Output $vol
+} else {
+    Write-Output "Usage: background-music-manager.ps1 {status|on|off|volume [X]|list|set-default TRACK|set-agent AGENT TRACK|set-all TRACK|get-enabled|get-volume}"
+    exit 1
+}

--- a/.claude/hooks-windows/play-tts.ps1
+++ b/.claude/hooks-windows/play-tts.ps1
@@ -89,12 +89,20 @@ if (Test-Path $ReverbFile) {
 $HasReverb = $ReverbLevel -ne "off"
 
 # Check ffmpeg availability for background music mixing or reverb
+# Refresh PATH from registry so newly-installed tools are found without shell restart
 $HasFfmpeg = $false
 if ($BgEnabled -or $HasReverb) {
     try {
         $null = Get-Command ffmpeg -ErrorAction Stop
         $HasFfmpeg = $true
-    } catch {}
+    } catch {
+        # PATH may be stale (common after winget install); refresh from registry
+        $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+        try {
+            $null = Get-Command ffmpeg -ErrorAction Stop
+            $HasFfmpeg = $true
+        } catch {}
+    }
 }
 
 # If background music or reverb enabled and ffmpeg available, tell provider to skip playback
@@ -152,31 +160,64 @@ if (($BgEnabled -or $HasReverb) -and $HasFfmpeg) {
 
         # Mix with background music if enabled
         if ($BgEnabled) {
-            # Get background track - default to bachata, or read from config
+            # Read background track and volume from audio-effects.cfg (matches Linux behavior)
             $TracksDir = "$ClaudeDir\audio\tracks"
-            $DefaultTrack = "agent_vibes_bachata_v1_loop.mp3"
-            $DefaultTrackFile = "$ConfigDir\background-music-default.txt"
-            if (Test-Path $DefaultTrackFile) {
-                $configTrack = (Get-Content $DefaultTrackFile -Raw).Trim()
-                # Validate: filename only, no path separators or traversal
-                if ($configTrack -and $configTrack -match '^[a-zA-Z0-9_\-\.]+$') {
-                    $DefaultTrack = $configTrack
+            $DefaultTrack = ""
+            $BgVolume = "0.25"
+            $AudioEffectsCfg = "$ConfigDir\audio-effects.cfg"
+
+            if (Test-Path $AudioEffectsCfg) {
+                # Try agent-specific config first, then fall back to default
+                # Format: AGENT_NAME|SOX_EFFECTS|BACKGROUND_FILE|BACKGROUND_VOLUME
+                $agentName = $env:AGENTVIBES_AGENT_NAME
+                $configLine = $null
+
+                $cfgLines = Get-Content $AudioEffectsCfg
+                if ($agentName) {
+                    foreach ($line in $cfgLines) {
+                        if ($line -match "^$([regex]::Escape($agentName))\|") {
+                            $configLine = $line
+                            break
+                        }
+                    }
+                }
+                # Fall back to default
+                if (-not $configLine) {
+                    foreach ($line in $cfgLines) {
+                        if ($line -match '^default\|') {
+                            $configLine = $line
+                            break
+                        }
+                    }
+                }
+
+                if ($configLine) {
+                    $parts = $configLine -split '\|'
+                    if ($parts.Length -ge 3 -and $parts[2]) {
+                        $trackName = $parts[2].Trim()
+                        # Validate: filename only, no path separators or traversal
+                        if ($trackName -match '^[a-zA-Z0-9_\-\.]+$') {
+                            $DefaultTrack = $trackName
+                        }
+                    }
+                    if ($parts.Length -ge 4 -and $parts[3]) {
+                        $volVal = $parts[3].Trim()
+                        if ($volVal -match '^\d+\.?\d*$') { $BgVolume = $volVal }
+                    }
                 }
             }
+
+            # Fallback if no track found in config
+            if (-not $DefaultTrack) {
+                $DefaultTrack = "agent_vibes_celtic_harp_v1_loop.mp3"
+            }
+
             $BgTrackPath = Join-Path $TracksDir $DefaultTrack
             # Path containment: verify resolved path stays within tracks directory
             $ResolvedBgTrack = [System.IO.Path]::GetFullPath($BgTrackPath)
             $ResolvedTracksDir = [System.IO.Path]::GetFullPath($TracksDir)
             if (-not $ResolvedBgTrack.StartsWith($ResolvedTracksDir + [System.IO.Path]::DirectorySeparatorChar)) {
-                $BgTrackPath = Join-Path $TracksDir "agent_vibes_bachata_v1_loop.mp3"
-            }
-
-            # Get volume (default 0.25)
-            $BgVolume = "0.25"
-            $VolumeFile = "$ConfigDir\background-music-volume.txt"
-            if (Test-Path $VolumeFile) {
-                $vol = (Get-Content $VolumeFile -Raw).Trim()
-                if ($vol -match '^\d+\.?\d*$') { $BgVolume = $vol }
+                $BgTrackPath = Join-Path $TracksDir "agent_vibes_celtic_harp_v1_loop.mp3"
             }
 
             if (Test-Path $BgTrackPath) {

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -684,9 +684,9 @@ class AgentVibesServer:
         # Parse track names
         tracks = []
         for line in list_result.split("\n"):
-            match = re.match(r'\s*\d+\.\s+(.+)', line)
+            match = re.match(r'\s*\d+\.\s+(.+)', line.strip())
             if match:
-                tracks.append(match.group(1))
+                tracks.append(match.group(1).strip())
 
         # Try to find a matching track (case-insensitive partial match)
         track_lower = track_name.lower()
@@ -721,7 +721,7 @@ class AgentVibesServer:
             # Set as default
             result = await self._run_script(self.BACKGROUND_MUSIC_MANAGER_SCRIPT, ["set-default", matched_track])
 
-        if result and "✅" in result:
+        if result and ("✅" in result or "[OK]" in result):
             if matched_track.lower() != track_name.lower():
                 return f"{result}\n\n🔍 Matched '{track_name}' to '{matched_track}'"
             return result

--- a/src/console/tabs/install-tab.js
+++ b/src/console/tabs/install-tab.js
@@ -16,6 +16,7 @@
 import path from 'node:path';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import fs from 'node:fs';
 import { promises as _fsP } from 'node:fs';
 import { buildAudioEnv } from '../audio-env.js';
 import {
@@ -91,7 +92,10 @@ export function formatGreeting(introText, projectName) {
  */
 async function _commandExistsAsync(cmd) {
   try {
-    await _execFileAsync(cmd, ['--version'], { stdio: 'pipe', timeout: 5000 });
+    // On Windows, commands like 'npm' are .cmd batch files that require shell: true
+    const opts = { stdio: 'pipe', timeout: 5000 };
+    if (process.platform === 'win32') opts.shell = true;
+    await _execFileAsync(cmd, ['--version'], opts);
     return true;
   } catch (err) {
     if (err.code === 'ENOENT') return false;
@@ -104,14 +108,26 @@ async function _commandExistsAsync(cmd) {
  * @returns {Promise<{ node: boolean, npm: boolean, piper: boolean, soprano: boolean }>}
  */
 async function _checkDependenciesAsync() {
-  const [node, npm, piper, sopranoTts, sopranoWebui] = await Promise.all([
+  const [node, npm, piperCmd, sopranoTts, sopranoWebui, ffmpeg] = await Promise.all([
     _commandExistsAsync('node'),
     _commandExistsAsync('npm'),
     _commandExistsAsync('piper'),
     _commandExistsAsync('soprano-tts'),
     _commandExistsAsync('soprano-webui'),
+    _commandExistsAsync('ffmpeg'),
   ]);
-  return { node, npm, piper, soprano: sopranoTts || sopranoWebui };
+
+  // On Windows, Piper is a standalone exe at %LOCALAPPDATA%\Programs\Piper\piper.exe
+  let piper = piperCmd;
+  if (!piper && process.platform === 'win32') {
+    const localAppData = process.env.LOCALAPPDATA ||
+      (process.env.USERPROFILE ? path.join(process.env.USERPROFILE, 'AppData', 'Local') : null);
+    if (localAppData) {
+      piper = fs.existsSync(path.join(localAppData, 'Programs', 'Piper', 'piper.exe'));
+    }
+  }
+
+  return { node, npm, piper, soprano: sopranoTts || sopranoWebui, ffmpeg };
 }
 
 // ---------------------------------------------------------------------------
@@ -628,6 +644,7 @@ export function createInstallTab(screen, services) {
       `  {${COLORS.labelFg}-fg}${'npm'.padEnd(14)}{/${COLORS.labelFg}-fg}${_deps.npm     ? ok() : bad()}`,
       `  {${COLORS.labelFg}-fg}${'Piper TTS'.padEnd(14)}{/${COLORS.labelFg}-fg}${_deps.piper   ? ok() : bad()}`,
       `  {${COLORS.labelFg}-fg}${'Soprano TTS'.padEnd(14)}{/${COLORS.labelFg}-fg}${_deps.soprano ? ok() : bad()}`,
+      `  {${COLORS.labelFg}-fg}${'ffmpeg'.padEnd(14)}{/${COLORS.labelFg}-fg}${_deps.ffmpeg  ? ok() : `{${COLORS.errorFg}-fg}⚠  Not found (needed for background music){/${COLORS.errorFg}-fg}`}`,
       '',
       ttsOk
         ? `  {${COLORS.successFg}-fg}✅  TTS Providers Detected{/${COLORS.successFg}-fg}`

--- a/src/installer.js
+++ b/src/installer.js
@@ -131,6 +131,24 @@ function isNativeWindows() {
 }
 
 /**
+ * Get the platform-correct Piper provider name
+ * Windows uses 'windows-piper', all other platforms use 'piper'
+ * @returns {string} The correct piper provider identifier
+ */
+function getPiperProvider() {
+  return isNativeWindows() ? 'windows-piper' : 'piper';
+}
+
+/**
+ * Check if a provider is any piper variant (piper or windows-piper)
+ * @param {string} provider - The provider name to check
+ * @returns {boolean} True if the provider is a piper variant
+ */
+function isPiperProvider(provider) {
+  return provider === 'piper' || provider === 'windows-piper';
+}
+
+/**
  * Detect if running on Android/Termux and display message
  * @returns {boolean} True if running on Termux/Android
  */
@@ -227,6 +245,21 @@ function getPersonalityIcon(personality, emojiSupported) {
  * @returns {boolean} True if piper command exists
  */
 function isPiperInstalled() {
+  // On Windows, check standard install location then PATH
+  if (isNativeWindows()) {
+    const localAppData = process.env.LOCALAPPDATA || (process.env.USERPROFILE ? path.join(process.env.USERPROFILE, 'AppData', 'Local') : null);
+    if (localAppData) {
+      const piperExe = path.join(localAppData, 'Programs', 'Piper', 'piper.exe');
+      if (fsSync.existsSync(piperExe)) return true;
+    }
+    // Also check PATH (e.g. pip-installed piper)
+    try {
+      execSync('where piper.exe', { stdio: 'pipe', timeout: 3000 });
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
   try {
     execSync('which piper', {
       stdio: 'pipe',
@@ -250,6 +283,19 @@ function isSopranoInstalled() {
     });
     return true;
   } catch (e) {
+    // On Windows, 'which' may not find Python scripts; try 'py -m pip show' as fallback
+    if (isNativeWindows()) {
+      try {
+        const result = spawnSync('py', ['-m', 'pip', 'show', 'soprano-tts'], {
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 10000
+        });
+        return result.status === 0 && result.stdout && result.stdout.includes('Name:');
+      } catch (e2) {
+        return false;
+      }
+    }
     return false;
   }
 }
@@ -292,7 +338,7 @@ async function playVoiceSample(voiceName, provider) {
     }
 
     // Generate sample on-the-fly if provider is running
-    if (provider === 'piper' && isPiperInstalled()) {
+    if (isPiperProvider(provider) && isPiperInstalled()) {
       const text = `Hi, I'm ${voiceName.split('-')[1] || 'Piper'}`;
       // Use bash -c with positional args to prevent command injection via text/voiceName
       spawnSync('bash', ['-c', 'echo "$1" | piper --model "$2" --output_raw | aplay -r 22050 -f S16_LE -t raw -', '_', text, voiceName], {
@@ -1518,19 +1564,19 @@ async function collectConfiguration(options = {}) {
 
       // Handle special receiver mode for Termux
       if (config.provider === 'piper-receiver') {
-        config.provider = 'piper';
+        config.provider = getPiperProvider();
         config.isReceiver = true;
       }
 
       // Handle silent mode (voiceless servers that don't want audio)
       if (config.provider === 'silent') {
         // Silent mode uses piper but won't actually play audio
-        config.provider = 'piper';
+        config.provider = getPiperProvider();
         config.isSilent = true;
       }
 
       // If Piper selected, ask for voice storage location
-      if (config.provider === 'piper' || config.provider === 'windows-piper' || config.isReceiver) {
+      if (isPiperProvider(config.provider) || config.isReceiver) {
         const homeDir = process.env.HOME || process.env.USERPROFILE;
         const defaultPiperPath = path.join(homeDir, '.claude', 'piper-voices');
 
@@ -1679,7 +1725,7 @@ async function collectConfiguration(options = {}) {
         voiceIntroMessage = chalk.white('Soprano Voice Configuration\n\n') +
                            chalk.gray('Soprano has a single premium neural voice.\n') +
                            chalk.gray('Voice details and specifications shown below.');
-      } else if (config.provider === 'piper') {
+      } else if (isPiperProvider(config.provider)) {
         voiceIntroMessage = chalk.white('Choose a default voice for your AgentVibes.\n\n') +
                            chalk.gray('Piper offers 50+ voices in 18+ languages.\n') +
                            chalk.gray('You can change this anytime with: ') + chalk.cyan('/agent-vibes:voice switch <name>');
@@ -1704,7 +1750,7 @@ async function collectConfiguration(options = {}) {
         }
       ));
 
-      if (config.provider === 'piper') {
+      if (isPiperProvider(config.provider)) {
         // Check if Piper is installed for voice previews
         const piperAvailable = isPiperInstalled();
 
@@ -2262,20 +2308,28 @@ async function collectConfiguration(options = {}) {
       config.backgroundMusic.enabled = enableMusic;
 
       if (enableMusic) {
-        // Check if an MP3-capable player is available; offer to install ffmpeg if not
+        // Check if ffmpeg is available; offer to install if not
         const { execSync: _execSync } = await import('child_process');
-        const _mp3Players = ['ffplay', 'mpg123', 'mpv', 'cvlc'];
-        const _hasPlayer = _mp3Players.some(p => {
-          try { _execSync(`which ${p}`, { stdio: 'pipe' }); return true; } catch { return false; }
-        });
-        if (!_hasPlayer) {
-          console.log('');
-          console.log(chalk.yellow('⚠️  No MP3 player found — background music requires one.'));
-          console.log(chalk.gray('   ffmpeg is recommended (provides ffplay for MP3 playback).\n'));
+        const _osPlatform = process.platform;
+        let _hasFfmpeg = false;
+        try {
+          if (_osPlatform === 'win32') {
+            _execSync('where ffmpeg', { stdio: 'pipe' });
+          } else {
+            _execSync('which ffmpeg', { stdio: 'pipe' });
+          }
+          _hasFfmpeg = true;
+        } catch {}
 
-          const _osPlatform = process.platform;
+        if (!_hasFfmpeg) {
+          console.log('');
+          console.log(chalk.yellow('⚠️  ffmpeg not found — required for background music mixing.'));
+          console.log(chalk.gray('   ffmpeg mixes background music with TTS voice output.\n'));
+
           let _installCmd;
-          if (_osPlatform === 'darwin') {
+          if (_osPlatform === 'win32') {
+            _installCmd = 'winget install --id Gyan.FFmpeg -e --source winget';
+          } else if (_osPlatform === 'darwin') {
             _installCmd = 'brew install ffmpeg';
           } else {
             // Prefer pkexec (GUI password dialog) when available — works in
@@ -2299,7 +2353,7 @@ async function collectConfiguration(options = {}) {
               try {
                 console.log(chalk.cyan(`\n📦 Running: ${_installCmd}\n`));
                 const { execSync: _exec } = await import('child_process');
-                _exec(_installCmd, { stdio: 'inherit', timeout: 120000 });
+                _exec(_installCmd, { stdio: 'inherit', timeout: 300000 });
                 console.log(chalk.green('\n✅ ffmpeg installed successfully!\n'));
               } catch {
                 console.log(chalk.yellow('\n⚠️  ffmpeg installation failed. You can install it manually:'));
@@ -4038,14 +4092,14 @@ async function checkAndInstallPiperWindows(targetDir, options) {
     return;
   }
   const voicesDir = path.join(homeDir, '.claude', 'piper-voices');
-  const voiceName = 'en_US-ryan-high';
+  const voiceName = 'en_US-lessac-medium';
   const modelFile = path.join(voicesDir, voiceName + '.onnx');
   if (!fsSync.existsSync(modelFile)) {
-    spinner.start('Downloading default voice (en_US-ryan-high)...');
+    spinner.start('Downloading default voice (en_US-lessac-medium)...');
     try {
       await fs.mkdir(voicesDir, { recursive: true });
-      const modelUrl = `https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/ryan/high/${voiceName}.onnx`;
-      const configUrl = `https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/ryan/high/${voiceName}.onnx.json`;
+      const modelUrl = `https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/${voiceName}.onnx`;
+      const configUrl = `https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/${voiceName}.onnx.json`;
       await downloadFile(modelUrl, modelFile);
       await downloadFile(configUrl, modelFile + '.json');
       spinner.succeed(chalk.green('Default voice downloaded!\n'));
@@ -4974,7 +5028,7 @@ async function install(options = {}) {
     const providerConfigPath = path.join(claudeDir, 'tts-provider.txt');
     await fs.writeFile(providerConfigPath, selectedProvider);
 
-    if (selectedProvider === 'piper' && piperVoicesPath) {
+    if (isPiperProvider(selectedProvider) && piperVoicesPath) {
       const piperConfigPath = path.join(claudeDir, 'piper-voices-dir.txt');
       await fs.writeFile(piperConfigPath, piperVoicesPath);
     }
@@ -5078,7 +5132,7 @@ Troubleshooting:
       switch (selectedProvider) {
         case 'piper':          defaultVoice = 'en_US-ryan-high'; break;
         case 'macos':          defaultVoice = 'Samantha'; break;
-        case 'windows-piper':  defaultVoice = 'en_US-ryan-high'; break;
+        case 'windows-piper':  defaultVoice = 'en_US-lessac-medium'; break;
         case 'windows-sapi':   defaultVoice = 'Microsoft David Desktop'; break;
         case 'soprano':        defaultVoice = 'soprano-default'; break;
         case 'termux-ssh':     defaultVoice = 'android-system-default'; break;
@@ -5091,12 +5145,13 @@ Troubleshooting:
     await detectAndMigrateOldConfig(targetDir, silentSpinner);
 
     // Auto-install Piper if selected
-    if (selectedProvider === 'piper') {
+    if (isPiperProvider(selectedProvider)) {
       spinner.text = 'Installing Piper TTS...';
-      await checkAndInstallPiper(targetDir, options);
-    } else if (selectedProvider === 'windows-piper') {
-      spinner.text = 'Installing Piper TTS for Windows...';
-      await checkAndInstallPiperWindows(targetDir, options);
+      if (isNativeWindows()) {
+        await checkAndInstallPiperWindows(targetDir, options);
+      } else {
+        await checkAndInstallPiper(targetDir, options);
+      }
     }
 
     // Apply background music configuration

--- a/src/utils/dependency-checker.js
+++ b/src/utils/dependency-checker.js
@@ -284,13 +284,16 @@ export function checkDependencies(options = {}) {
     }
   }
 
-  // Optional tools (Unix-only — Windows uses native providers)
+  // Optional tools
   if (!isWindows) {
     results.optional.sox = commandExists('sox');
     if (!results.optional.sox) {
       results.missing.sox = true;
     }
+  }
 
+  // ffmpeg is needed on ALL platforms for background music mixing
+  {
     results.optional.ffmpeg = commandExists('ffmpeg');
     if (!results.optional.ffmpeg) {
       results.missing.ffmpeg = true;


### PR DESCRIPTION
## Summary
- Background music on Windows now reads from audio-effects.cfg (same as Linux)
- ffmpeg auto-install via winget during installer
- New background-music-manager.ps1 (full Windows port)
- PATH auto-refresh so ffmpeg works without shell restart

## Changes (6 files only)
- .claude/hooks-windows/background-music-manager.ps1 (NEW)
- .claude/hooks-windows/play-tts.ps1
- mcp-server/server.py
- src/console/tabs/install-tab.js
- src/installer.js
- src/utils/dependency-checker.js

Generated with [Claude Code](https://claude.com/claude-code)