### PR TITLE
docs: add missing -p flag to npx command in MCP setup guides

### DIFF
--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -48,7 +48,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
   "mcpServers": {
     "agentvibes": {
       "command": "npx",
-      "args": ["-y", "agentvibes@beta", "agentvibes-mcp-server"]
+      "args": ["-y", "-p", "agentvibes@beta", "agentvibes-mcp-server"]
     }
   }
 }
@@ -63,7 +63,7 @@ Add to `~/.warp/mcp.json`:
 {
   "agentvibes": {
     "command": "npx",
-    "args": ["-y", "agentvibes@beta", "agentvibes-mcp-server"],
+    "args": ["-y", "-p", "agentvibes@beta", "agentvibes-mcp-server"],
     "env": {
     }
   }
@@ -79,7 +79,7 @@ Add to `.mcp-minimal.json` in your project:
   "mcpServers": {
     "agentvibes": {
       "command": "npx",
-      "args": ["-y", "agentvibes@beta", "agentvibes-mcp-server"],
+      "args": ["-y", "-p", "agentvibes@beta", "agentvibes-mcp-server"],
       "env": {
       }
     }

--- a/mcp-server/WINDOWS_SETUP.md
+++ b/mcp-server/WINDOWS_SETUP.md
@@ -121,7 +121,7 @@ Now we'll tell Claude Desktop to use AgentVibes.
        "mcpServers": {
          "agentvibes": {
            "command": "npx",
-           "args": ["-y", "agentvibes@beta", "agentvibes-mcp-server"]
+           "args": ["-y", "-p", "agentvibes@beta", "agentvibes-mcp-server"]
          }
        }
      }

--- a/mcp-server/docs/troubleshooting-audio.md
+++ b/mcp-server/docs/troubleshooting-audio.md
@@ -270,7 +270,7 @@ Your config file has syntax errors:
      "mcpServers": {
        "agentvibes": {
          "command": "npx",
-         "args": ["-y", "agentvibes@beta", "agentvibes-mcp-server"]
+         "args": ["-y", "-p", "agentvibes@beta", "agentvibes-mcp-server"]
        }
      }
    }


### PR DESCRIPTION
## Summary

- The `agentvibes` npm package exposes multiple bins (`agentvibes`, `agent-vibes`, `test-bmad-pr`, `agentvibes-mcp-server`). Because the requested bin name differs from the package name, `npx` needs `-p`/`--package` to resolve it.
- Without the flag, `npx -y agentvibes@beta agentvibes-mcp-server` exits with code 1 and produces no output, so the MCP server never starts in Claude Desktop / Claude Code / Warp.
- `docs/installation/INSTALL_MCP_WINDOWS.md` already documents the correct form (with an explicit `❌ Missing -p` callout). This PR aligns the other three setup guides to match.

## Files updated

- `docs/mcp-setup.md` (3 code blocks: Claude Desktop, Warp, Claude Code)
- `mcp-server/WINDOWS_SETUP.md`
- `mcp-server/docs/troubleshooting-audio.md`

## Test plan

- [x] Verified `npm view agentvibes@beta bin` shows multiple bins, confirming `-p` is required
- [x] Confirmed the old form (`npx -y agentvibes@beta agentvibes-mcp-server`) exits with code 1 and no output
- [x] Confirmed the new form (`npx -y -p agentvibes@beta agentvibes-mcp-server`) launches the MCP server successfully
- [ ] Copy the updated `claude_desktop_config.json` snippet into a fresh config and verify the MCP tools register

🤖 Generated with [Claude Code](https://claude.com/claude-code)