### PR TITLE
fix(setup-tab): retry next WAV player when Piper preview playback fails

### DIFF
--- a/src/console/tabs/setup-tab.js
+++ b/src/console/tabs/setup-tab.js
@@ -45,7 +45,7 @@ import { formatTrackName } from '../widgets/format-utils.js';
 import { destroyList } from '../widgets/destroy-list.js';
 import { scanInstalledVoices, getVoiceMeta, genderIconTag, formatVoiceRow, voiceRowHeader, PIPER_VOICES_DIR, SAMPLE_PHRASES, parseMultiSpeaker, getFavorites, getThumbsDown, toggleFavorite, toggleThumbsUp, toggleThumbsDown } from './voices-tab.js';
 import { attachBtnBlink } from './agents-tab.js';
-import { buildAudioEnv, detectWavPlayer } from '../audio-env.js';
+import { buildAudioEnv, getAllWavPlayers } from '../audio-env.js';
 import { spawn, spawnSync } from 'node:child_process';
 import os from 'node:os';
 import crypto from 'node:crypto';
@@ -4207,20 +4207,51 @@ export function createSetupTab(screen, services) {
           try { fs.unlinkSync(tempWav); } catch {};
           return;
         }
-        const wp = detectWavPlayer(_spawnEnv);
-        if (!wp) return;
-        const pp = spawn(wp.bin, wp.args(tempWav), {
-          stdio: 'ignore',
-          detached: !_isWin,
-          windowsHide: true,
-          env: _spawnEnv,
-        });
-        _previewProc = pp;
-        if (!_vpClosed) { vpPreviewLine.setContent(`{cyan-fg}♪ Playing: ${voiceId}{/cyan-fg}`); screen.render(); }
-        pp.on('exit', () => {
-          if (_previewVoiceId === voiceId) { _previewVoiceId = null; _previewProc = null; if (!_vpClosed) { vpPreviewLine.setContent(''); _refreshVP(); } }
+        // Play the synthesized wav — try each installed player until one succeeds.
+        // A single detectWavPlayer() pick can be present but non-functional (e.g.
+        // sox's `play` exits 1 with "no default audio device configured"), which
+        // would otherwise fail silently since there was no exit-code check here.
+        const _wavPlayers = getAllWavPlayers(_spawnEnv);
+        if (_wavPlayers.length === 0) {
+          _previewProc = null; _previewVoiceId = null;
           try { fs.unlinkSync(tempWav); } catch {}
-        });
+          return;
+        }
+
+        function _tryNextPlayer(remainingPlayers) {
+          if (_previewVoiceId !== voiceId) { try { fs.unlinkSync(tempWav); } catch {} return; }
+          if (!remainingPlayers.length) {
+            _previewProc = null; _previewVoiceId = null;
+            if (!_vpClosed) {
+              vpPreviewLine.setContent('{red-fg}♪ Audio playback failed (no audio device?){/red-fg}');
+              screen.render();
+              setTimeout(() => { if (!_vpClosed) { vpPreviewLine.setContent(''); screen.render(); } }, 4000);
+            }
+            try { fs.unlinkSync(tempWav); } catch {}
+            return;
+          }
+          const [wavP, ...rest] = remainingPlayers;
+          const pp = spawn(wavP.bin, wavP.args(tempWav), {
+            stdio: 'ignore',
+            detached: !_isWin,
+            windowsHide: true,
+            env: _spawnEnv,
+          });
+          _previewProc = pp;
+          if (!_vpClosed) { vpPreviewLine.setContent(`{cyan-fg}♪ Playing: ${voiceId}{/cyan-fg}`); screen.render(); }
+          pp.on('exit', (code) => {
+            if (_previewVoiceId !== voiceId) { try { fs.unlinkSync(tempWav); } catch {} return; }
+            if (code !== 0) { _tryNextPlayer(rest); return; }
+            _previewVoiceId = null; _previewProc = null;
+            if (!_vpClosed) { vpPreviewLine.setContent(''); _refreshVP(); }
+            try { fs.unlinkSync(tempWav); } catch {}
+          });
+          pp.on('error', () => {
+            if (_previewVoiceId !== voiceId) { try { fs.unlinkSync(tempWav); } catch {} return; }
+            _tryNextPlayer(rest);
+          });
+        }
+        _tryNextPlayer(_wavPlayers);
       });
       piper.on('error', () => {
         _previewProc = null; _previewVoiceId = null;


### PR DESCRIPTION
## Summary
- The provider-config wizard's Piper voice picker (`setup-tab.js` `_previewVoice`) picked a single WAV player via `detectWavPlayer()` and never checked its exit code, so a present-but-broken player failed silently with no sound and no error message.
- Root cause reproduced on this machine: sox's `play` (installed via scoop) is detected before `ffplay`/PowerShell, but exits 1 with "no default audio device configured" — the picker just showed "♪ Playing..." then went quiet.
- Kokoro previews don't hit this because they bypass the WAV_PLAYERS list entirely (hardcoded PowerShell `SoundPlayer`), and the separate Voices tab already has retry-on-failure logic via `getAllWavPlayers()` — this brings the setup-tab picker in line with that existing pattern.

## Test plan
- [x] `node --test test/unit/setup-tab-preview-routing.test.js test/unit/tui-voice-preview-routing.test.js test/unit/setup-tab-audio-suppress.test.js` — 53/53 pass
- [x] `bash scripts/run-tests.sh` (full suite: syntax, bats, coverage) — exit 0
- [x] Manually confirmed on this machine: `sox play` exits 1 ("no default audio device"), `ffplay` (next in the fallback chain) plays the same file successfully with exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)